### PR TITLE
ci: add golangci linter and get runner shell

### DIFF
--- a/.github/workflows/get-runner-access.yaml
+++ b/.github/workflows/get-runner-access.yaml
@@ -1,0 +1,24 @@
+name: Action runner access
+on:
+  pull_request:
+
+jobs:
+  get-runner-shell:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: setup minikube
+      uses: manusa/actions-setup-minikube@v2.4.2
+      with:
+        minikube version: 'v1.23.2'
+        kubernetes version: 'v1.22.2'
+        start args: --memory 6g --cpus=2
+        github token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: setup tmate session for debugging when event is PR
+      if: always()
+      uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,29 @@
+name: golangci-lint
+on:
+  pull_request:
+
+jobs:
+  golangci:
+    name: golangci-lint
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.41
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          args: -E gosec  --timeout=6m
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true


### PR DESCRIPTION
Adding Golang ci linter also, I'll  require
runner shell to test setting intree and flex
cluster. So, basically second job is to access
to github action runner with minikube.

Signed-off-by: subhamkrai <srai@redhat.com>