### PR TITLE
core: support single pvc support

### DIFF
--- a/.github/workflows/flex-migration-test.yaml
+++ b/.github/workflows/flex-migration-test.yaml
@@ -16,32 +16,34 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.4.2
+    - name: setup cluster resources
+      uses: ./.github/workflows/setup-cluster-resources
       with:
-        minikube version: 'v1.23.2'
-        kubernetes version: 'v1.22.2'
-        start args: --memory 6g --cpus=2
-        github token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: print k8s cluster status
-      run:  |
-        minikube status
-        kubectl get nodes
+    - name: Test migration of all PVC
+      run: tests/script/github_action_helper.sh test_flex_migration_for_all_pvc
 
-    - name: use local disk
-      run: tests/script/github_action_helper.sh use_local_disk
+    - name: setup tmate session for debugging when event is PR
+      if: failure()
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 300
 
-    - name: Install yq
-      run: |
-        sudo wget -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64
-        sudo chmod +x /usr/local/bin/yq
+  Flex-Mirgate-single-PVC:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
-    - name: setup flex
-      run: tests/script/github_action_helper.sh deploy_rook_ceph_with_flex
+    - name: setup cluster resources
+      uses: ./.github/workflows/setup-cluster-resources
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: test flex migration
-      run: tests/script/github_action_helper.sh test_flex_migration
+    - name: Test migration of all PVC
+      run: tests/script/github_action_helper.sh test_flex_migration_for_single_pvc
 
     - name: setup tmate session for debugging when event is PR
       if: failure()

--- a/.github/workflows/setup-cluster-resources/action.yaml
+++ b/.github/workflows/setup-cluster-resources/action.yaml
@@ -1,0 +1,37 @@
+name: Setup Cluster Resources
+description: Setup cluster resources required for migration
+inputs:
+  github-token:
+    description: GITHUB_TOKEN from the calling workflow
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: setup minikube
+      uses: manusa/actions-setup-minikube@v2.4.2
+      with:
+        minikube version: "v1.23.2"
+        kubernetes version: "v1.22.2"
+        start args: --memory 6g --cpus=2
+        github token: ${{ inputs.github-token }}
+
+    - name: print k8s cluster status
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      run:  |
+        minikube status
+        kubectl get nodes
+
+    - name: use local disk
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      run: tests/script/github_action_helper.sh use_local_disk
+
+    - name: Install yq
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      run: |
+        sudo wget -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64
+        sudo chmod +x /usr/local/bin/yq
+
+    - name: setup flex
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      run: tests/script/github_action_helper.sh deploy_rook_ceph_with_flex

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -27,6 +27,8 @@ var (
 	destinationStorageClass string
 	rookNamespace           string
 	cephClusterNamespace    string
+	pvcName                 string
+	pvcNamespace            string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -46,7 +48,7 @@ var rootCmd = &cobra.Command{
 	// 9. Delete old PV object
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := migration.MigrateToCSI(kubeConfig, sourceStorageClass,
-			destinationStorageClass, rookNamespace, cephClusterNamespace); err != nil {
+			destinationStorageClass, rookNamespace, cephClusterNamespace, pvcName, pvcNamespace); err != nil {
 			return err
 		}
 		return nil
@@ -70,4 +72,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&destinationStorageClass, "destinationstorageclass", "", "destination storageclass (CSI storageclass) to which all PVC need to be migrated")
 	rootCmd.PersistentFlags().StringVar(&rookNamespace, "rook-namespace", "rook-ceph", "Kubernetes namespace where rook operator is running")
 	rootCmd.PersistentFlags().StringVar(&cephClusterNamespace, "ceph-cluster-namespace", "rook-ceph", "Kubernetes namespace where ceph cluster is created")
+	rootCmd.PersistentFlags().StringVar(&pvcName, "pvc", "", "Name of the specific pvc you want to migrate")
+	rootCmd.PersistentFlags().StringVar(&pvcNamespace, "pvc-namespace", "", "Namespace of the specific pvc you want to migrate")
 }

--- a/pkg/k8sutil/pvc.go
+++ b/pkg/k8sutil/pvc.go
@@ -65,6 +65,22 @@ func ListAllPVCWithStorageclass(client *k8s.Clientset, scName string) (*[]corev1
 	return pl, nil
 }
 
+func ListSinglePVCWithStorageclass(client *k8s.Clientset, pvcName, pvcNamespace string) (*[]corev1.PersistentVolumeClaim, error) {
+	pl := &[]corev1.PersistentVolumeClaim{}
+
+	pvc, err := client.CoreV1().PersistentVolumeClaims(pvcNamespace).Get(context.TODO(), pvcName, v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	if pvc.Name == pvcName {
+		*pl = append(*pl, *pvc)
+		return pl, nil
+	}
+
+	return pl, nil
+}
+
 func DeletePVC(client *k8s.Clientset, pvc *corev1.PersistentVolumeClaim) error {
 	err := client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(context.TODO(), pvc.Name, v1.DeleteOptions{})
 	if err != nil {

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -14,7 +14,7 @@ const (
 	pvcCreateTimeout = 5
 )
 
-func MigrateToCSI(kubeConfig, sourceStorageClass, destinationStorageClass, rookNamespace, cephClusterNamespace string) error {
+func MigrateToCSI(kubeConfig, sourceStorageClass, destinationStorageClass, rookNamespace, cephClusterNamespace, pvcName, pvcNamespace string) error {
 	// TODO
 	/*
 		add validation to check source,destination storageclass and Rook namespace
@@ -28,14 +28,27 @@ func MigrateToCSI(kubeConfig, sourceStorageClass, destinationStorageClass, rookN
 	}
 
 	logger.DefaultLog("List all the PVC from the source storageclass")
-	pvcs, err := k8sutil.ListAllPVCWithStorageclass(client, sourceStorageClass)
-	if err != nil {
-		return fmt.Errorf("failed to list PVCs from the storageclass: %v", err)
+	var pvcs *[]v1.PersistentVolumeClaim
+	if pvcNamespace != "" && pvcName != "" {
+		pvcs, err = k8sutil.ListSinglePVCWithStorageclass(client, pvcName, pvcNamespace)
+		if err != nil {
+			return fmt.Errorf("failed to list PVCs from the pvc name %s and pvc namespace %s : %v", pvcName, pvcNamespace, err)
+		}
+		if pvcs == nil || len(*pvcs) == 0 {
+			logger.DefaultLog("no PVCs found with the pvc name %s and pvc namespace %s : %v", pvcName, pvcNamespace, err)
+			return nil
+		}
+	} else {
+		pvcs, err = k8sutil.ListAllPVCWithStorageclass(client, sourceStorageClass)
+		if err != nil {
+			return fmt.Errorf("failed to list PVCs from the storageclass: %v", err)
+		}
+		if pvcs == nil || len(*pvcs) == 0 {
+			logger.DefaultLog("no PVCs found with storageclass: %v", sourceStorageClass)
+			return nil
+		}
 	}
-	if pvcs == nil || len(*pvcs) == 0 {
-		logger.DefaultLog("no PVCs found with storageclass: %v", sourceStorageClass)
-		return nil
-	}
+
 	logger.DefaultLog("%d PVCs found with source StorageClass %s ", len(*pvcs), sourceStorageClass)
 
 	logger.DefaultLog("Start Migration of PVCs to CSI")


### PR DESCRIPTION
adding flag `pvcName` which take the name of the
PVC users want to migrate and along with sourcestorageClass
flag.
This commit will enable support for a single PVC.

- [x] Add code to support single PVC 
- [x] CI to test this scenario
- [x] manual testing

Closes: https://github.com/ceph/persistent-volume-migrator/issues/17
Signed-off-by: subhamkrai <srai@redhat.com>