### PR TITLE
tool: change the name from toolbox to migrator

### DIFF
--- a/tests/manifests/migrator.yaml
+++ b/tests/manifests/migrator.yaml
@@ -3,24 +3,24 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: rook-ceph-tools
+  name: rook-ceph-migrator
   namespace: rook-ceph # namespace:cluster
   labels:
-    app: rook-ceph-tools
+    app: rook-ceph-migrator
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: rook-ceph-tools
+      app: rook-ceph-migrator
   template:
     metadata:
       labels:
-        app: rook-ceph-tools
+        app: rook-ceph-migrator
     spec:
-      serviceAccountName: rook-ceph-tools # only this field was newly added
+      serviceAccountName: rook-ceph-migrator # only this field was newly added
       dnsPolicy: ClusterFirstWithHostNet
       containers:
-        - name: rook-ceph-tools
+        - name: rook-ceph-migrator
           image: rook/ceph:v1.7.5
           command: ["/tini"]
           args: ["-g", "--", "/usr/local/bin/toolbox.sh"]

--- a/tests/manifests/modified_common.yaml
+++ b/tests/manifests/modified_common.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: rook-ceph-tools
+  name: rook-ceph-migrator
 rules:
   - apiGroups: [""]
     resources: ["namespaces"]
@@ -38,21 +38,21 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: rook-ceph-tools
+  name: rook-ceph-migrator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rook-ceph-tools
+  name: rook-ceph-migrator
 subjects:
   - kind: ServiceAccount
-    name: rook-ceph-tools
+    name: rook-ceph-migrator
     namespace: rook-ceph # namespace:cluster
 
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: rook-ceph-tools
+  name: rook-ceph-migrator
   namespace: rook-ceph # namespace:cluster
 # imagePullSecrets:
 # - name: my-registry-secret
@@ -64,7 +64,7 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: rook-ceph-tools
+  name: rook-ceph-migrator
   namespace: rook-ceph # namespace:cluster
 rules:
   - apiGroups: [""]
@@ -80,22 +80,22 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: rook-ceph-tools
+  name: rook-ceph-migrator
   namespace: rook-ceph # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: rook-ceph-tools
+  name: rook-ceph-migrator
 subjects:
   - kind: ServiceAccount
-    name: rook-ceph-tools
+    name: rook-ceph-migrator
     namespace: rook-ceph # namespace:cluster
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: rook-ceph-tools-psp
+  name: rook-ceph-migrator-psp
   namespace: rook-ceph # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -103,6 +103,6 @@ roleRef:
   name: psp:rook
 subjects:
   - kind: ServiceAccount
-    name: rook-ceph-tools
+    name: rook-ceph-migrator
     namespace: rook-ceph # namespace:cluster
 ---


### PR DESCRIPTION
this commit changes the name from toolbox to migrator
as the RBAC that was added can be removed after the use
of the tool. And, users don't get confused with the default
toolbox.

Signed-off-by: subhamkrai <srai@redhat.com>
