### PR TITLE
pvc: don't default namespace while pvc delete

### DIFF
--- a/pkg/k8sutil/pvc.go
+++ b/pkg/k8sutil/pvc.go
@@ -66,7 +66,7 @@ func ListAllPVCWithStorageclass(client *k8s.Clientset, scName string) (*[]corev1
 }
 
 func DeletePVC(client *k8s.Clientset, pvc *corev1.PersistentVolumeClaim) error {
-	err := client.CoreV1().PersistentVolumeClaims("default").Delete(context.TODO(), pvc.Name, v1.DeleteOptions{})
+	err := client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(context.TODO(), pvc.Name, v1.DeleteOptions{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It was bug that we're deleting pvc from
`default` namespace. We should be deleting
pvc from `pvc.Namespace`.

Signed-off-by: subhamkrai <srai@redhat.com>