### PR TITLE
core: create directory to store keys

### DIFF
--- a/pkg/ceph/rbd/rbd.go
+++ b/pkg/ceph/rbd/rbd.go
@@ -29,6 +29,11 @@ const (
 )
 
 func storeKey(key string) (string, error) {
+	err := os.MkdirAll(tmpKeyFileLocation, 0700)
+	if err != nil {
+		return "", fmt.Errorf("error creating a temporary directory %s: %w", tmpKeyFileLocation, err)
+	}
+
 	tmpfile, err := ioutil.TempFile(tmpKeyFileLocation, tmpKeyFileNamePrefix)
 	if err != nil {
 		return "", fmt.Errorf("error creating a temporary keyfile: %w", err)

--- a/tests/script/github_action_helper.sh
+++ b/tests/script/github_action_helper.sh
@@ -58,7 +58,7 @@ test_flex_migration() {
   go build main.go
   TOOLBOX_POD=$(kubectl -n rook-ceph get pod -l app=rook-ceph-tools -o jsonpath='{.items[*].metadata.name}')
   kubectl -n rook-ceph cp main "$TOOLBOX_POD":/root/
-  kubectl -n rook-ceph exec -it "$TOOLBOX_POD" -- sh -c "mkdir -p /tmp/csi/keys && cd root/ && ./main flexToCSI --sourcestoraageclass=rook-ceph-block --destinationstorageclass=csi-rook-ceph-block"
+  kubectl -n rook-ceph exec -it "$TOOLBOX_POD" -- sh -c "cd root/ && ./main flexToCSI --sourcestoraageclass=rook-ceph-block --destinationstorageclass=csi-rook-ceph-block"
   kubectl create -f https://raw.githubusercontent.com/rook/rook/release-1.7/cluster/examples/kubernetes/ceph/csi/rbd/pod.yaml
   wait_for_sample_pod_to_be_ready_state
   verify_file_data_and_file_data


### PR DESCRIPTION
Creating directory `/tmp/csi/keys` store
keys that are required to make connections.

Signed-off-by: subhamkrai <srai@redhat.com>