### PR TITLE
core: remove the directory created for storing keys

### DIFF
--- a/pkg/ceph/rbd/connection.go
+++ b/pkg/ceph/rbd/connection.go
@@ -45,6 +45,7 @@ func NewConnection(monitor, id, key, pool, datapool string) (*Connection, error)
 	}, nil
 }
 
-func (c *Connection) Destroy() error {
-	return os.Remove(c.KeyFile)
+func RemoveKeyDir() error {
+	// remove the directory which was created specially for storing key. This will also remove key file.
+	return os.Remove("/tmp/csi/keys")
 }

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"fmt"
 
+	"persistent-volume-migrator/pkg/ceph/rbd"
 	"persistent-volume-migrator/pkg/k8sutil"
 	logger "persistent-volume-migrator/pkg/log"
 
@@ -112,7 +113,7 @@ func migratePVC(client *k8s.Clientset, pvc v1.PersistentVolumeClaim, destination
 		return fmt.Errorf("failed to get cluster config %v", err)
 	}
 	defer func() {
-		err = conn.Destroy()
+		err = rbd.RemoveKeyDir()
 		if err != nil {
 			logger.ErrorLog("failed to destroy the connection: %v", err)
 		}


### PR DESCRIPTION
Removing directory directly instead of removing the key file.

Signed-off-by: subhamkrai <srai@redhat.com>