### PR TITLE
core: use `os.RemoveAll()` to remove non empty dir

### DIFF
--- a/pkg/ceph/rbd/connection.go
+++ b/pkg/ceph/rbd/connection.go
@@ -47,5 +47,5 @@ func NewConnection(monitor, id, key, pool, datapool string) (*Connection, error)
 
 func RemoveKeyDir() error {
 	// remove the directory which was created specially for storing key. This will also remove key file.
-	return os.Remove("/tmp/csi/keys")
+	return os.RemoveAll("/tmp/csi/keys")
 }


### PR DESCRIPTION
Earlier, it was `os.Remove()` so it was giving error
`directory not empty`. So, now we use `os.Remove.All()`.

Signed-off-by: subhamkrai <srai@redhat.com>