### PR TITLE
ci: add Markdown linter for docs

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,4 +1,4 @@
-name: golangci-lint
+name: Golangci-lint
 on:
   pull_request:
 

--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -1,0 +1,16 @@
+name: Markdown-lint
+on:
+  pull_request:
+
+jobs:
+  lint-Markdown:
+    name: Lint markdown file
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Lint markdown file
+      uses: docker://avtodev/markdown-lint:v1
+      with:
+        args: './README.md'

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # persistent-volume-migrator
+
 Tool to migrate Kubernetes In-tree and Flex volumes to Ceph-CSI


### PR DESCRIPTION
Adding Markdown linter for docs.

Closes: https://github.com/ceph/persistent-volume-migrator/issues/32
Signed-off-by: subhamkrai <srai@redhat.com>