### PR TITLE
Add support for Intree driver migration

### DIFF
--- a/manifests/migrator.yaml
+++ b/manifests/migrator.yaml
@@ -118,7 +118,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: rook-ceph-migrator
-          image: rook/ceph:v1.7.8
+          image: rook/ceph:v1.7.11
           command: ["/tini"]
           args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
           imagePullPolicy: IfNotPresent

--- a/pkg/k8sutil/pv.go
+++ b/pkg/k8sutil/pv.go
@@ -78,8 +78,14 @@ func UpdateReclaimPolicy(client *k8s.Clientset, pv *corev1.PersistentVolume) err
 }
 
 func GetVolumeName(pv *corev1.PersistentVolume) string {
-	// Rook creates rbd image with PV name
-	return pv.Name
+	// check if Volume is provisioned by FlexVolume Driver.
+	if pv.Spec.FlexVolume != nil {
+		// In case of FlexVolume driver, rbd image is created with the PV name.
+		return pv.Name
+	}
+	// else in the case of volume provisioned by the intree driver,
+	// return the imagename from the spec.
+	return pv.Spec.RBD.RBDImage
 }
 
 func WaitForRBDImage(pv *corev1.PersistentVolume) string {


### PR DESCRIPTION
Add support to migrate volumes provisioned by Intree driver to that of CSI.

Note: We don't need to pass any extra parameters to notify the tool about the source driver.
The migration tool usage remains the same for both FlexVolume as well as the In-tree drivers.

For e.g: In a namespace with 10 PVCs, with 5 provisioned by FlexVolume and the other 5 by Intree;
all the PVCs can be migrated with the same binary and flags :)
