### PR TITLE
Allow for CSI provisioned volume or storage class as source

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 The persistent-volume-migrator tool aims to help migrate Flex RBD Volumes to
 [Ceph-CSI](https://github.com/ceph/ceph-csi) RBD Volumes.
 
-> **Note** Migration of CephFS FlexVolumes is not supported for now.
+Migration between Ceph-CSI Volumes is also supported.
+
+> **Note** Migration of CephFS Volumes is not supported for now.
 
 ## Getting Started
 

--- a/pkg/k8sutil/pv.go
+++ b/pkg/k8sutil/pv.go
@@ -83,9 +83,18 @@ func GetVolumeName(pv *corev1.PersistentVolume) string {
 		// In case of FlexVolume driver, rbd image is created with the PV name.
 		return pv.Name
 	}
-	// else in the case of volume provisioned by the intree driver,
-	// return the imagename from the spec.
-	return pv.Spec.RBD.RBDImage
+	// check if Volume is provisioned by the intree driver.
+	if pv.Spec.RBD != nil {
+		// return the imagename from the spec.
+		return pv.Spec.RBD.RBDImage
+	}
+	// check if Volume is provisioned by the CSI driver.
+	if pv.Spec.CSI != nil {
+		// return the imagename from the spec.
+		return pv.Spec.CSI.VolumeAttributes["imageName"]
+	}
+	// unable to find the volume name.
+	return ""
 }
 
 func WaitForRBDImage(pv *corev1.PersistentVolume) string {


### PR DESCRIPTION
I understand it is not the intention of the project as clearly stated in the readme, but I found with this small change it is possible to migrate from CSI to CSI volumes.

Our use case is migrating from a flex driver storage class, to a temporary csi storage class, deleting the flex storage class, and migrating to a csi storage class with the same name as the original flex storage class.